### PR TITLE
Fix login check syntax

### DIFF
--- a/app-functional.js
+++ b/app-functional.js
@@ -1169,6 +1169,7 @@ function showUserMenu() {
 
 function checkUserLogin() {
     const user = JSON.parse(localStorage.getItem('studyingflash_user') || '{}');
+    if (user.loggedIn) {
         updateUIForLoggedUser(user.email);
     }
 }


### PR DESCRIPTION
## Summary
- fix checkUserLogin body to properly guard on loggedIn

## Testing
- `node scripts/enhanced_agent1_coordinator_fixed.cjs verifyStandards`
- `npm test` *(fails: Could not resolve "" in vitest config)*
- `pytest -q` *(fails: ModuleNotFoundError for `backend_app`)*

------
https://chatgpt.com/codex/tasks/task_b_68748761e32083339c7c735cd4427b16